### PR TITLE
Remove username and channel

### DIFF
--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -15,12 +15,10 @@ on:
       - '.github/workflows/zlib.yml'
 
 env:
-  CONAN_USERNAME: 'trassir'
   CONAN_LOGIN_USERNAME: 'trassir-ci-bot'
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
   CONAN_UPLOAD: 'https://api.bintray.com/conan/trassir/conan-public'
   CONAN_UPLOAD_ONLY_WHEN_STABLE: 1
-  CONAN_STABLE_CHANNEL: 'stable'
   CONAN_STABLE_BRANCH_PATTERN: 'trassir-ci'
   CONAN_REMOTES: 'https://api.bintray.com/conan/trassir/conan-public'
   CONAN_REFERENCE: 'zlib/1.2.11'


### PR DESCRIPTION
We cannot use trassir/stable for packages from conan-center-index, as username and channel has become optional in conan, and conan-center-index maintainers has decided to remove them from dependencies' description in recipes.

Recipes without username/channel are converted into '_/_' (username/channel) and are not
found.

E.g. we have zlib/1.2.11@trassir/stable in our bintray but openssl recipe requires zlib/1.2.11, so it searches for zlib/1.2.11@_/_.

It's not an option to fix every recipe we need in this monorepository, so let's adhere to their conversion.

We still can use username/channel for our recipes if there is such a need.