### PR TITLE
Use IS_PURE_C envvar to speed up C libraries build

### DIFF
--- a/.github/workflows/libalsa.yml
+++ b/.github/workflows/libalsa.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
-  IS_PURE_C: 1
+  IS_PURE_C: true
 
 jobs:
   libalsa:

--- a/.github/workflows/libalsa.yml
+++ b/.github/workflows/libalsa.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
+  IS_PURE_C: 1
 
 jobs:
   libalsa:

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
-  IS_PURE_C: 1
+  IS_PURE_C: true
 
 jobs:
   openssl:

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
+  IS_PURE_C: 1
 
 jobs:
   openssl:

--- a/.github/workflows/zlib-1.2.11.yml
+++ b/.github/workflows/zlib-1.2.11.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
+  IS_PURE_C: 1
 
 jobs:
   zlib_1_2_11:

--- a/.github/workflows/zlib-1.2.11.yml
+++ b/.github/workflows/zlib-1.2.11.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
-  IS_PURE_C: 1
+  IS_PURE_C: true
 
 jobs:
   zlib_1_2_11:

--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 from os import environ
 from sys import platform
 from cpt.packager import ConanMultiPackager
+from cpt.tools import get_bool_from_env
 
 
 if __name__ == "__main__":
@@ -14,6 +15,7 @@ if __name__ == "__main__":
         if not environ["CONAN_REFERENCE"].endswith("@/"):
             environ["CONAN_REFERENCE"] += "@/"
 
+    is_pure_c = get_bool_from_env('IS_PURE_C')
     builder = ConanMultiPackager(
         login_username="trassir-ci-bot",
         upload="https://api.bintray.com/conan/trassir/conan-public",
@@ -22,5 +24,5 @@ if __name__ == "__main__":
         stable_channel="_",
         remotes="https://api.bintray.com/conan/trassir/conan-public"
     )
-    builder.add_common_builds(pure_c=False)
+    builder.add_common_builds(pure_c=is_pure_c)
     builder.run()


### PR DESCRIPTION
Currently, always using `pure_c=False` leads to C libraries like Zlib or OpenSSL building twice: using the setting `libcxx=libstdc++` and `libcxx=libstdc++11`; even despite that said setting is [explicitly deleted in recipe](https://github.com/trassir/conan-center-index/blob/trassir-ci/recipes/zlib/1.2.11/conanfile.py#L27).

CPT does not provide an envvar to control `pure_c` parameter, so I've come up with self-invented one.