### PR TITLE
Replace conanio/gcc{7,8} in all workflows

### DIFF
--- a/.github/workflows/axtls-1.5.3.yml
+++ b/.github/workflows/axtls-1.5.3.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/boost.yml
+++ b/.github/workflows/boost.yml
@@ -28,7 +28,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
             boost_version: '1.69.0'

--- a/.github/workflows/bzip2-1.0.6.yml
+++ b/.github/workflows/bzip2-1.0.6.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/ffmpeg-3.3.1.yml
+++ b/.github/workflows/ffmpeg-3.3.1.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/icu.yml
+++ b/.github/workflows/icu.yml
@@ -28,7 +28,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/jansson.yml
+++ b/.github/workflows/jansson.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/jasper.yml
+++ b/.github/workflows/jasper.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/jbig.yml
+++ b/.github/workflows/jbig.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/jsoncpp.yml
+++ b/.github/workflows/jsoncpp.yml
@@ -27,7 +27,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
             conan_reference: "jsoncpp/1.8.3"

--- a/.github/workflows/libalsa.yml
+++ b/.github/workflows/libalsa.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/libiconv.yml
+++ b/.github/workflows/libiconv.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/libpq.yml
+++ b/.github/workflows/libpq.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/libtiff.yml
+++ b/.github/workflows/libtiff.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/libuuid.yml
+++ b/.github/workflows/libuuid.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/libxml2.yml
+++ b/.github/workflows/libxml2.yml
@@ -28,7 +28,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/miniupnpc-2.1.yml
+++ b/.github/workflows/miniupnpc-2.1.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/opencv-2.4.13.5.yml
+++ b/.github/workflows/opencv-2.4.13.5.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/openexr-2.3.0.yml
+++ b/.github/workflows/openexr-2.3.0.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'

--- a/.github/workflows/protoc-3.9.1.yml
+++ b/.github/workflows/protoc-3.9.1.yml
@@ -28,7 +28,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/xz_utils.yml
+++ b/.github/workflows/xz_utils.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '8'
-            docker_image: 'conanio/gcc8'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'macos'

--- a/.github/workflows/yasm.yml
+++ b/.github/workflows/yasm.yml
@@ -29,7 +29,7 @@ jobs:
             os: 'ubuntu-latest'
             compiler: 'gcc'
             compiler_version: '7'
-            docker_image: 'conanio/gcc7'
+            docker_image: 'trassiross/conan-gcc8'
             build_types: 'Release'
             archs: 'x86_64'
           - build: 'windows-2019-release'


### PR DESCRIPTION
Replaced "official" Docker images for gcc 7 and 8 with custom-built one from https://github.com/trassir/conan-config/commit/240486edd6977719227105dee73d07a51d519165