### PR TITLE
CI for b2

### DIFF
--- a/.github/workflows/b2.yml
+++ b/.github/workflows/b2.yml
@@ -1,0 +1,64 @@
+name: b2 CI
+
+on:
+  pull_request:
+    paths:
+      - 'recipes/b2/all/**'
+      - 'build.py'
+      - '.github/workflows/b2.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'recipes/b2/all/**'
+      - 'build.py'
+      - '.github/workflows/b2.yml'
+
+env:
+  IS_PURE_C: true # it is a binary, so we don't care about compiler.libcxx
+  CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
+
+jobs:
+  b2:
+    strategy:
+      matrix:
+        build: ['linux-gcc8']
+        b2_versions: ['4.2.0']
+        include:
+          - build: 'linux-gcc8'
+            os: 'ubuntu-latest'
+            compiler: 'gcc'
+            compiler_version: '8'
+            docker_image: 'trassiross/conan-gcc8'
+            build_types: 'Release'
+            archs: 'x86_64'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+        shell: bash
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: sources
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Build and Optionally Upload
+        uses: trassir/run-cpt@v0.2.2-trassir
+        with:
+          install: custom
+          # TODO: replace when https://github.com/conan-io/conan-package-tools/issues/479 will be fixed upstream
+          custom-package: git+https://github.com/trassir/conan-package-tools@fix-479-trassir
+          work-dir: sources/recipes/b2/all
+          build-script: ../../../build.py
+          compiler: ${{ matrix.compiler }}
+          compiler-versions: ${{ matrix.compiler_version }}
+          docker-images: ${{ matrix.docker_image }}
+        env:
+          CONAN_VISUAL_RUNTIMES: ${{ matrix.vs_runtimes }}
+          CONAN_ARCHS: ${{ matrix.archs }}
+          CONAN_BUILD_TYPES: ${{ matrix.build_types }}
+          CONAN_REFERENCE: b2/${{ matrix.b2_versions }}
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer


### PR DESCRIPTION
Чтобы собирать Boost в нашем докере со старой убунтой, нужно пересобрать в нём же и утилиту `b2`, в противном случае она не запускается из-за расхождения glibc