### PR TITLE
package protobuf shared libraries with protoc

### DIFF
--- a/recipes/protoc/3.9.1/conanfile.py
+++ b/recipes/protoc/3.9.1/conanfile.py
@@ -49,9 +49,6 @@ class ProtocConanFile(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         # when built with protobuf:shared=True, protoc will require its libraries to run
         # so we copy those from protobuf package


### PR DESCRIPTION
Workaround for `protoc: error while loading shared libraries: libprotoc.so.3.9.1.0: cannot open shared object file: No such file or directory`.