### PR TITLE
add possibility to provide ldflags from json

### DIFF
--- a/recipes/x11/all/manage.py
+++ b/recipes/x11/all/manage.py
@@ -38,6 +38,7 @@ class {classname}Conan({baseclass}):
         super({classname}Conan, self).package_info()
         {libs}
         {system_libs}
+        {sharedlinkflags}
 """
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -86,6 +87,10 @@ def gen(args):
             patches = info["patches"] if "patches" in info else "[]"
             baseclass = "BaseHeaderOnly" if header_only else "BaseLib"
             namespace = info["namespace"] if "namespace" in info else "lib"
+            sharedlinkflags = ""
+            if "ldflags" in info:
+                sharedlinkflags = ['"%s"' % flag for flag in info["ldflags"]]
+                sharedlinkflags = "self.cpp_info.sharedlinkflags.extend([%s])" % ", ".join(sharedlinkflags)
             content = conanfile_template.format(sha256=info["sha256"],
                                                 version=info["version"],
                                                 description=info["description"],
@@ -95,6 +100,7 @@ def gen(args):
                                                 baseclass=baseclass,
                                                 libs=libs,
                                                 system_libs=system_libs,
+                                                sharedlinkflags=sharedlinkflags,
                                                 classname=classname,
                                                 patches=patches)
             f.write(content)

--- a/recipes/x11/all/x11.json
+++ b/recipes/x11/all/x11.json
@@ -50,7 +50,8 @@
         "sha256": "f09a76971437780a602303170fd51b5f7474051722bc39d566a272d2c4bde1b5",
         "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface",
         "namespace": "xcb",
-        "requires": ["xcb-proto", "util-macros", "libXau", "libpthread-stubs", "libXdmcp"]
+        "requires": ["xcb-proto", "util-macros", "libXau", "libpthread-stubs", "libXdmcp"],
+        "ldflags": ["-lXau", "-lXdmcp"]
     },
     {
         "name": "libX11",


### PR DESCRIPTION
В некоторых случаях для сборки пакетов, использующих библиотеки x11, собранные в виде разделяемых, необходимо указывать флаги линковки, в которых требуется перечислять зависимости библиотек x11, объявленных как private.

Например, это нужно при сборке xkbcommon, которая использует libxcb и линкуется с ней, однако не линкуется с ее приватными зависимостями  - libXau и libXdmcp.
