### PR TITLE
dont declare libxau and libxdmcp as private deps

### DIFF
--- a/recipes/x11/all/patches/xcb.patch
+++ b/recipes/x11/all/patches/xcb.patch
@@ -1,0 +1,10 @@
+--- libxcb-1.13.1-orig/xcb.pc.in
++++ libxcb-1.13.1/xcb.pc.in
+@@ -8,6 +8,5 @@
+ Description: X-protocol C Binding
+ Version: @PACKAGE_VERSION@
+ Requires.private: @NEEDED@
+-Libs: -L${libdir} -lxcb
+-Libs.private: @LIBS@
++Libs: -L${libdir} -lxcb @LIBS@
+ Cflags: -I${includedir}

--- a/recipes/x11/all/x11.json
+++ b/recipes/x11/all/x11.json
@@ -50,7 +50,8 @@
         "sha256": "f09a76971437780a602303170fd51b5f7474051722bc39d566a272d2c4bde1b5",
         "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface",
         "namespace": "xcb",
-        "requires": ["xcb-proto", "util-macros", "libXau", "libpthread-stubs", "libXdmcp"]
+        "requires": ["xcb-proto", "util-macros", "libXau", "libpthread-stubs", "libXdmcp"],
+        "patches": ["xcb.patch"]
     },
     {
         "name": "libX11",


### PR DESCRIPTION
Патч убирает объявление зависимостей libxcb от libxau и libxdmcp в качестве приватных и делает их публичными

