### PR TITLE
Disable iconv for odbc on macos

### DIFF
--- a/.github/workflows/odbc.yml
+++ b/.github/workflows/odbc.yml
@@ -40,7 +40,6 @@ jobs:
             compiler: 'apple_clang'
             compiler_version: '11.0'
             xcode_version: '11.4'
-            conan_options: 'odbc:with_libiconv=False'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git
@@ -71,5 +70,4 @@ jobs:
           CONAN_ARCHS: ${{ matrix.archs }}
           CONAN_BUILD_TYPES: ${{ matrix.build_types }}
           CONAN_REFERENCE: odbc/${{ matrix.odbc_versions }}
-          CONAN_OPTIONS: ${{ matrix.conan_options }}
           DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/.github/workflows/odbc.yml
+++ b/.github/workflows/odbc.yml
@@ -40,6 +40,7 @@ jobs:
             compiler: 'apple_clang'
             compiler_version: '11.0'
             xcode_version: '11.4'
+            conan_options: 'odbc:with_libiconv=False'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git
@@ -70,4 +71,5 @@ jobs:
           CONAN_ARCHS: ${{ matrix.archs }}
           CONAN_BUILD_TYPES: ${{ matrix.build_types }}
           CONAN_REFERENCE: odbc/${{ matrix.odbc_versions }}
+          CONAN_OPTIONS: ${{ matrix.conan_options }}
           DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/recipes/odbc/all/conanfile.py
+++ b/recipes/odbc/all/conanfile.py
@@ -25,9 +25,9 @@ class OdbcConan(ConanFile):
             raise ConanInvalidConfiguration("Windows not supported yet. Please, open an issue if you need such support")
 
     def requirements(self):
-        if self.options.with_libiconv:
+        if self.options.with_libiconv and not tools.is_apple_os(self.settings.os):
             self.requires("libiconv/1.15")
-        
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = 'unixODBC-%s' % self.version
@@ -43,7 +43,10 @@ class OdbcConan(ConanFile):
                 '--enable-ltdl-install',
                 '--enable-iconv=%s' % libiconv_flag]
         if self.options.with_libiconv:
-            libiconv_prefix = self.deps_cpp_info["libiconv"].rootpath
+            if tools.is_apple_os(self.settings.os):
+                libiconv_prefix = "/usr"
+            else:
+                libiconv_prefix = self.deps_cpp_info["libiconv"].rootpath
             args.append('--with-libiconv-prefix=%s' % libiconv_prefix)
 
         env_build.configure(configure_dir=self._source_subfolder, args=args)


### PR DESCRIPTION
MacOS have internal iconv library which causes conflicts
Force odbc to link system iconv library