### PR TITLE
link with all built x11 libraries

### DIFF
--- a/recipes/x11/all/conanfile_base.py
+++ b/recipes/x11/all/conanfile_base.py
@@ -21,6 +21,7 @@ class BaseHeaderOnly(ConanFile):
                                         os.path.join("lib", "pkgconfig")])
         self.cpp_info.includedirs = [path for path in self.cpp_info.includedirs if os.path.isdir(path)]
         self.cpp_info.libdirs = [path for path in self.cpp_info.libdirs if os.path.isdir(path)]
+        self.cpp_info.libs = tools.collect_libs(self)
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Для того, чтобы Трассир линковался с конановскими бибилиотеками x11, а не с системными, необходимо передавать их линкеру через -l.