### PR TITLE
icu: use version 63.2 for qtwebkit

### DIFF
--- a/.github/workflows/icu.yml
+++ b/.github/workflows/icu.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         build: ['linux-gcc8', 'macos']
-        icu_versions: ['64.2']
+        icu_versions: ['63.2']
         include:
           - build: 'linux-gcc8'
             os: 'ubuntu-latest'

--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "63.2":
+    url: "https://github.com/unicode-org/icu/releases/download/release-63-2/icu4c-63_2-src.tgz"
+    sha256: "4671e985b5c11252bff3c2374ab84fd73c609f2603bb6eb23b8b154c69ea4215"
   "64.2":
     url: "https://github.com/unicode-org/icu/releases/download/release-64-2/icu4c-64_2-src.tgz"
     sha256: "627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c"

--- a/recipes/icu/config.yml
+++ b/recipes/icu/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "63.2":
+    folder: all
   "64.2":
     folder: all


### PR DESCRIPTION
Для вебкита на линуксе нужна icu 63.2, с 64.2 он падает