### PR TITLE
zlib, bzip2, openssl: run test packages on win32

### DIFF
--- a/recipes/bzip2/1.0.8/test_package/conanfile.py
+++ b/recipes/bzip2/1.0.8/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
     def test(self):
         assert os.path.isfile(os.path.join(self.deps_cpp_info["bzip2"].rootpath, "licenses", "LICENSE"))
         assert os.path.isfile(os.path.join(self.build_folder, "bzip2.pc"))
-        if tools.cross_building(self.settings):
+        if tools.cross_building(self.settings, skip_x64_x86=(self.settings.os == "Windows")):
             self.output.warn("Skipping run cross built package")
             return
 

--- a/recipes/openssl/all/test_package/conanfile.py
+++ b/recipes/openssl/all/test_package/conanfile.py
@@ -28,7 +28,7 @@ class DefaultNameConan(ConanFile):
         self._build_cmake(use_find_package=False)
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self.settings, skip_x64_x86=(self.settings.os == "Windows")):
             bin_path = os.path.join("bin", "digest")
             self.run(bin_path, run_environment=True)
         assert os.path.exists(os.path.join(self.deps_cpp_info["openssl"].rootpath, "licenses", "LICENSE"))

--- a/recipes/zlib/1.2.11/test_package/conanfile.py
+++ b/recipes/zlib/1.2.11/test_package/conanfile.py
@@ -20,7 +20,8 @@ class TestZlibConan(ConanFile):
     def test(self):
         assert os.path.exists(os.path.join(self.deps_cpp_info["zlib"].rootpath, "licenses", "LICENSE"))
         assert os.path.exists(os.path.join(self.build_folder, "zlib.pc"))
-        if "x86" in self.settings.arch and not tools.cross_building(self.settings):
+        if "x86" in self.settings.arch and\
+                not tools.cross_building(self.settings, skip_x64_x86=(self.settings.os == "Windows")):
             self.run(os.path.join("bin", "test"), run_environment=True)
             if self.options["zlib"].minizip:
                 self.run(os.path.join("bin", "test_minizip"), run_environment=True)


### PR DESCRIPTION
Cross build from x86_64 to x86 on windows should not prevent running the executable.