### PR TITLE
Ffmpeg 3.3.1 win32 CI, vc 2019

### DIFF
--- a/.github/workflows/ffmpeg-3.3.1.yml
+++ b/.github/workflows/ffmpeg-3.3.1.yml
@@ -48,7 +48,7 @@ jobs:
         if: matrix.os == 'macos-10.15'
         run: brew install pkg-config
       - name: Configure git
-        run: git config --global core.autocrlf input
+        run: git config --global core.autocrlf false
         shell: bash
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ffmpeg-win32-3.3.1.yml
+++ b/.github/workflows/ffmpeg-win32-3.3.1.yml
@@ -1,0 +1,65 @@
+name: ffmpeg-3.3.1 win32 CI
+
+on:
+  pull_request:
+    paths:
+      - 'recipes/ffmpeg/3.3.1/**'
+      - 'build.py'
+      - '.github/workflows/ffmpeg-3.3.1.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'recipes/ffmpeg/3.3.1/**'
+      - 'build.py'
+      - '.github/workflows/ffmpeg-3.3.1.yml'
+
+env:
+  CONAN_PASSWORD: ${{ secrets.BintrayApiKey }}
+  CONAN_ARCHS: 'x86'
+  IS_PURE_C: true
+
+jobs:
+  ffmpeg:
+    strategy:
+      matrix:
+        build: ['windows-2019-release', 'windows-2019-debug']
+        include:
+          - build: 'windows-2019-release'
+            build_types: 'Release'
+            vs_runtimes: 'MD,MT'
+            compiler: 'vs'
+            compiler_version: '16'
+          - build: 'windows-2019-debug'
+            build_types: 'Debug'
+            vs_runtimes: 'MDd,MTd'
+            compiler: 'vs'
+            compiler_version: '16'
+    runs-on: 'windows-2019'
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+        shell: bash
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: sources
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: ffmpeg - Build and Optionally Upload
+        uses: trassir/run-cpt@v0.2.2-trassir
+        with:
+          install: custom
+          # TODO: replace when https://github.com/conan-io/conan-package-tools/issues/479 will be fixed upstream
+          custom-package: git+https://github.com/trassir/conan-package-tools@fix-479-trassir
+          work-dir: sources/recipes/ffmpeg/3.3.1
+          build-script: ../../../build.py
+          compiler: ${{ matrix.compiler }}
+          compiler-versions: ${{ matrix.compiler_version }}
+        env:
+          CONAN_VISUAL_RUNTIMES: ${{ matrix.vs_runtimes }}
+          CONAN_BUILD_TYPES: ${{ matrix.build_types }}
+          CONAN_REFERENCE: 'ffmpeg/3.3.1'
+          CONAN_MSYS_PATH: 'C:\\msys64\\usr\\bin'


### PR DESCRIPTION
Минимальная сборка, с единственной внешней библиотекой: [libmfx/qsv](https://www.ffmpeg.org/general.html#Intel-QuickSync-Video) (хардварное ускорение для intel cpu). По результатам анализа её, возможно, будем делать другую расширенную сборку, содержающую другие библиотеки.