### PR TITLE
remove skipping system version for conan recipes

### DIFF
--- a/builder/conan_tools.py
+++ b/builder/conan_tools.py
@@ -33,8 +33,6 @@ def _is_gha_buildable(line):
         return False
     if '# GHA: ignore' in line:
         return False
-    if '/system' in line:
-        return False
     if '@' in line:
         return False
     if '/' not in line:


### PR DESCRIPTION
system version packages install packages on system(apt-get, yum and other)
It is assumed that the packages are already installed on the system.
This fix is needed only for building on GHA