### PR TITLE
T19869: use activate.sh in mac conanfile.txt for compatibility

### DIFF
--- a/trassir/mac-clang11/conanfile.txt
+++ b/trassir/mac-clang11/conanfile.txt
@@ -1,5 +1,6 @@
 [generators]
 cmake
+virtualenv
 virtualrunenv
 
 [requires]

--- a/trassir/win64-vc142/conanfile.txt
+++ b/trassir/win64-vc142/conanfile.txt
@@ -58,7 +58,7 @@ xz_utils/5.2.4.dssl2
 zlib/1.2.11
 
 [options]
-Tevian:shared=True
+tevian:shared=True
 axtls:shared=True
 boost:shared=True
 bzip2:build_executable=True


### PR DESCRIPTION
https://success.trassir.com/D12104

`tevian` is a missing change from commit in monorepo `0813f37c95e6 NOTICKET: rename Tevian to tevian` by `v.looze`

, which in turn is a follow-up to `dbd869a38b2b T18803: facesdk lost files` by `f.lebedev` ( #386  )